### PR TITLE
chore: pinned version of super-linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Lint Codebase
         id: super-linter
-        uses: super-linter/super-linter/slim@latest
+        uses: super-linter/super-linter/slim@v6.7.0
         env:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: dist/**/*


### PR DESCRIPTION
Latest version of SuperLinter is breaking the CI.